### PR TITLE
[1.12.2] Durability Rebalance

### DIFF
--- a/src/main/java/com/mangregory/asgardshieldreloaded/config/ASRConfig.java
+++ b/src/main/java/com/mangregory/asgardshieldreloaded/config/ASRConfig.java
@@ -91,7 +91,7 @@ public class ASRConfig
         public int SKULL_GIANT_SWORD_MAXUSEDURATION = 100;
 
         @Config.Name("Ender Giant Sword: Durability")
-        public int ENDER_GIANT_SWORD_DURABILITY = 1829;
+        public int ENDER_GIANT_SWORD_DURABILITY = 1529;
 
         @Config.Name("Ender Giant Sword: Damage")
         public double ENDER_GIANT_SWORD_DAMAGE = 8.0D;

--- a/src/main/java/com/mangregory/asgardshieldreloaded/config/ASRConfig.java
+++ b/src/main/java/com/mangregory/asgardshieldreloaded/config/ASRConfig.java
@@ -55,7 +55,7 @@ public class ASRConfig
         public int GOLD_GIANT_SWORD_MAXUSEDURATION = 100;
 
         @Config.Name("Diamond Giant Sword: Durability")
-        public int DIAMOND_GIANT_SWORD_DURABILITY = 2341;
+        public int DIAMOND_GIANT_SWORD_DURABILITY = 2241;
 
         @Config.Name("Diamond Giant Sword: Damage")
         public double DIAMOND_GIANT_SWORD_DAMAGE = 8.0D;

--- a/src/main/java/com/mangregory/asgardshieldreloaded/config/ASRConfig.java
+++ b/src/main/java/com/mangregory/asgardshieldreloaded/config/ASRConfig.java
@@ -28,7 +28,7 @@ public class ASRConfig
         public int WOODEN_GIANT_SWORD_MAXUSEDURATION = 100;
 
         @Config.Name("Stone Giant Sword: Durability")
-        public int STONE_GIANT_SWORD_DURABILITY = 196;
+        public int STONE_GIANT_SWORD_DURABILITY = 176;
 
         @Config.Name("Stone Giant Sword: Damage")
         public double STONE_GIANT_SWORD_DAMAGE = 6.0D;
@@ -37,7 +37,7 @@ public class ASRConfig
         public int STONE_GIANT_SWORD_MAXUSEDURATION = 100;
 
         @Config.Name("Iron Giant Sword: Durability")
-        public int IRON_GIANT_SWORD_DURABILITY = 375;
+        public int IRON_GIANT_SWORD_DURABILITY = 475;
 
         @Config.Name("Iron Giant Sword: Damage")
         public double IRON_GIANT_SWORD_DAMAGE = 7.0D;
@@ -64,7 +64,7 @@ public class ASRConfig
         public int DIAMOND_GIANT_SWORD_MAXUSEDURATION = 100;
 
         @Config.Name("Nether Quartz Giant Sword: Durability")
-        public int NETHERQUARTZ_GIANT_SWORD_DURABILITY = 1646;
+        public int NETHERQUARTZ_GIANT_SWORD_DURABILITY = 525;
 
         @Config.Name("Nether Quartz Giant Sword: Damage")
         public double NETHERQUARTZ_GIANT_SWORD_DAMAGE = 7.0D;
@@ -73,7 +73,7 @@ public class ASRConfig
         public int NETHERQUARTZ_GIANT_SWORD_MAXUSEDURATION = 100;
 
         @Config.Name("Patchwork Giant Sword: Durability")
-        public int PATCHWORK_GIANT_SWORD_DURABILITY = 40;
+        public int PATCHWORK_GIANT_SWORD_DURABILITY = 45;
 
         @Config.Name("Patchwork Giant Sword: Damage")
         public double PATCHWORK_GIANT_SWORD_DAMAGE = 5.0D;
@@ -82,7 +82,7 @@ public class ASRConfig
         public int PATCHWORK_GIANT_SWORD_MAXUSEDURATION = 100;
 
         @Config.Name("Skull Giant Sword: Durability")
-        public int SKULL_GIANT_SWORD_DURABILITY = 260;
+        public int SKULL_GIANT_SWORD_DURABILITY = 360;
 
         @Config.Name("Skull Giant Sword: Damage")
         public double SKULL_GIANT_SWORD_DAMAGE = 6.0D;
@@ -175,13 +175,13 @@ public class ASRConfig
         public int GILDED_NETHERQUARTZ_SHIELD_MAXUSEDURATION = 200;
 
         @Config.Name("Patchwork Shield: Durability")
-        public int PATCHWORK_SHIELD_DURABILITY = 54;
+        public int PATCHWORK_SHIELD_DURABILITY = 60;
 
         @Config.Name("Patchwork Shield: Max Use Duration")
         public int PATCHWORK_SHIELD_MAXUSEDURATION = 200;
 
         @Config.Name("Gilded Patchwork Shield: Durability")
-        public int GILDED_PATCHWORK_SHIELD_DURABILITY = 182;
+        public int GILDED_PATCHWORK_SHIELD_DURABILITY = 188;
 
         @Config.Name("Gilded Patchwork Shield: Max Use Duration")
         public int GILDED_PATCHWORK_SHIELD_MAXUSEDURATION = 200;
@@ -199,13 +199,13 @@ public class ASRConfig
         public int GILDED_SKULL_SHIELD_MAXUSEDURATION = 200;
 
         @Config.Name("Ender Shield: Durability")
-        public int ENDER_SHIELD_DURABILITY = 435;
+        public int ENDER_SHIELD_DURABILITY = 450;
 
         @Config.Name("Ender Shield: Max Use Duration")
         public int ENDER_SHIELD_MAXUSEDURATION = 200;
 
         @Config.Name("Gilded Ender Shield: Durability")
-        public int GILDED_ENDER_SHIELD_DURABILITY = 563;
+        public int GILDED_ENDER_SHIELD_DURABILITY = 578;
 
         @Config.Name("Gilded Ender Shield: Max Use Duration")
         public int GILDED_ENDER_SHIELD_MAXUSEDURATION = 200;

--- a/src/main/resources/assets/asr/lang/en_us.lang
+++ b/src/main/resources/assets/asr/lang/en_us.lang
@@ -14,8 +14,8 @@ item.asr.gilded_iron_shield.name=Gilded Iron Shield
 item.asr.netherquartz_shield.name=Nether Quartz Shield
 item.asr.gilded_netherquartz_shield.name=Gilded Nether Quartz Shield
 
-item.asr.patchwork_shield.name=Patchwork Shield
-item.asr.gilded_patchwork_shield.name=Gilded Patchwork Shield
+item.asr.patchwork_shield.name=Patchwork Torso
+item.asr.gilded_patchwork_shield.name=Gilded Patchwork Torso
 
 item.asr.skull_shield.name=Skull Shield
 item.asr.gilded_skull_shield.name=Gilded Skull Shield

--- a/src/main/resources/assets/asr/recipes/netherquartz_giant_sword.json
+++ b/src/main/resources/assets/asr/recipes/netherquartz_giant_sword.json
@@ -8,7 +8,7 @@
   "key": {
     "Q": {
       "type": "forge:ore_dict",
-      "ore": "blockQuartz"
+      "ore": "gemQuartz"
     },
     "B": {
       "item": "minecraft:blaze_rod"

--- a/src/main/resources/assets/asr/recipes/netherquartz_shield.json
+++ b/src/main/resources/assets/asr/recipes/netherquartz_shield.json
@@ -8,7 +8,7 @@
   "key": {
     "Q": {
       "type": "forge:ore_dict",
-      "ore": "blockQuartz"
+      "ore": "gemQuartz"
     },
     "L": {
       "type": "forge:ore_dict",


### PR DESCRIPTION
- Fixed inconsistent durability (especially for quartz) when compared to the original 1.5.2 version. Durability for certain materials were adjusted to be more balanced.
- Reverted recipe changes to quartz items due to the above.
- Renamed 'Patchwork Shield' to 'Patchwork Torso' (applies to the gilded variant too).

**Durability Changes:**
[Ender Giant Sword]: 1829 > 1529
[Ender Shield]: 435 > 450
[Diamond Giant Sword]: 2341 > 2241
[Gilded Ender Shield]: 563 > 578
[Gilded Patchwork Shield]: 182 > 188
[Iron Giant Sword]: 375 > 475
[Nether Quartz Giant Sword]: 1646 (!) > 525
[Patchwork Leg]: 40 > 45
[Patchwork Torso]: 54 > 60
[Skull Giant Sword]: 260 > 360
[Stone Giant Sword]: 196 > 176